### PR TITLE
Bash-scripting-enabling entry script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 docker.lock
 bin/
 !bin/dcv
+!bin/entry_script.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ USER dcv
 VOLUME /input
 WORKDIR /input
 
-ENTRYPOINT ["/dcv/bin/dcv"]
+ENTRYPOINT ["/dcv/bin/entry_script.sh"]
 CMD ["render", "-m", "image", "-f"]

--- a/bin/entry_script.sh
+++ b/bin/entry_script.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+set -e
+
+CURRENT_DIR=$(dirname $0)
+
+if [ "$1" = "render" ]
+then
+    $("$CURRENT_DIR/dcv" "$@")
+else
+    exec "$@"
+fi


### PR DESCRIPTION
This entry script allows to run some bash scripts/commands. When command begins with "render", then the command is passed to original `/dcv/bin/dcv` script.