### PR TITLE
feat: Add xdg-open support to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.1-alpine
 
 RUN apk update && \
-    apk add graphviz ttf-dejavu && \
+    apk add graphviz ttf-dejavu feh xdg-utils file && \
     rm -rf \
         /var/cache/apk/* \
         /tmp/*


### PR DESCRIPTION
Closes #27 

Some commands to test:

```sh
# 1st terminal window
socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\"

#2nd terminal window
ip=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
docker run -it -v $(pwd):/input -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$ip:0 dcv render -m display /input/docker-compose.yml
```