### PR TITLE
Added support for long volume format fixes #36

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -313,7 +313,7 @@ function makeVerticesAndEdges(Graph $graph, array $services, array $volumes, arr
                 } else {
                     list($host, $container, $attr) = explodeMapping($volume);
                 }
-                
+
                 $serviceVolumes[$container] = [$host, $attr];
             }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -306,8 +306,14 @@ function makeVerticesAndEdges(Graph $graph, array $services, array $volumes, arr
             $serviceVolumes = [];
 
             foreach ($definition['volumes'] ?? [] as $volume) {
-                list($host, $container, $attr) = explodeMapping($volume);
-
+                if (is_array($volume)) {
+                    $host = $volume['source'];
+                    $container = $volume['target'];
+                    $attr = $volume['read_only'] ? 'ro' : '';
+                } else {
+                    list($host, $container, $attr) = explodeMapping($volume);
+                }
+                
                 $serviceVolumes[$container] = [$host, $attr];
             }
 


### PR DESCRIPTION
Added check for arrays in volume description.
When the description is an array, set the variables from the array, otherwise split the string as before.