### PR TITLE
Support for port long syntax

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -334,7 +334,14 @@ function makeVerticesAndEdges(Graph $graph, array $services, array $volumes, arr
 
         if (false === ((bool) ($flags & WITHOUT_PORTS))) {
             foreach ($definition['ports'] ?? [] as $port) {
-                list($target, $host, $container, $proto) = explodePortMapping($port);
+                if (is_array($port)) {
+                    $target = null;
+                    $host = $port['published'];
+                    $container = $port['target'];
+                    $proto = $port['protocol'] ?? null;
+                } else {
+                    list($target, $host, $container, $proto) = explodePortMapping($port);
+                }
 
                 addRelation(
                     addPort($graph, (int) $host, $proto, $target),


### PR DESCRIPTION
Use case: https://docs.docker.com/compose/compose-file/compose-file-v3/#ports

```
  ports:
  - published: 80
    target: 8080
  - published: 9101
    target: 9101
```